### PR TITLE
HoaLibrary for MaxPackageDL

### DIFF
--- a/max_packages.json
+++ b/max_packages.json
@@ -61,5 +61,12 @@
     "link": "https://github.com/stretta/BEAP/archive/master.zip",
     "relative_path": "None"
   }
+
+  "HoaLibrary":
+  {
+    "enabled": "true",
+    "link": "https://github.com/CICM/HoaLibrary/archive/master.zip",
+    "relative_path": "_distribution/Max"
+  },
  
 }


### PR DESCRIPTION
Salut,
J'espère que le package Hoa est bien formaté. Si j'ai bien compris, nous devons ajouter un lien vers le projet comme ça : "https://github.com/CICM/HoaLibrary/archive/master.zip" (notre Master doit faire dans les 1.2 Go, ça ne pose pas de problèmes ?) et rajouter le chemin vers le "package-info.json".
