### PR TITLE
Fixed link to package-info.json for cs.2click

### DIFF
--- a/max_packages_master.json
+++ b/max_packages_master.json
@@ -74,7 +74,7 @@
 	"cs.2click":
 	{
 		"enabled": "true",
-		"link": "https://github.com/delucis/cs.2click/archive/master.zip",
+		"link": "https://raw.githubusercontent.com/delucis/cs.2click/master/package-info.json",
 		"relative_path": "None"
 	}
 ,


### PR DESCRIPTION
Sorry! I misunderstood the max_packages_master.json file and linked it to the repo’s download ZIP rather than the package-info.json file. This fixes that.

Thanks again,
Chris.